### PR TITLE
Fix missing slash for API V3 URLs

### DIFF
--- a/+siibra/+internal/API.m
+++ b/+siibra/+internal/API.m
@@ -4,7 +4,7 @@ classdef API
     properties (Constant=true)
         Endpoint = "https://siibra-api-stable.apps.hbp.eu/v1_0/"
         EndpointV2 = "https://siibra-api-stable.apps.hbp.eu/v2_0"
-        EndpointV3 = "https://siibra-api-stable.apps.hbp.eu/v3_0"
+        EndpointV3 = "https://siibra-api-stable.apps.hbp.eu/v3_0/"
     end
 
     methods (Static)


### PR DESCRIPTION
In my testing, it's quite apparent this added forward slash is needed to use the V3 web API.
Without this forward slash, 404 errors (such as 👇🏼) are returned that show the slash clearly missing in the constructed URL.

![image](https://github.com/user-attachments/assets/f2301b00-2f0f-4c01-a420-97a792bbd6ef)

 _⚠️For testing updates to the API endpoints Constant properties in `siibra.internal.API`, I find that `clear classes` must be used between each change. Otherwise, the previous information remains in memory for the class. It seems the execution engine doesn't anticipate Constant variables to change in typical interactive programming._ 

